### PR TITLE
Syntax: ignore semi-colons

### DIFF
--- a/language/syntax.js
+++ b/language/syntax.js
@@ -48,6 +48,7 @@ const SYMBOLS = {
  */
 const META_SYMBOLS = {
   Comment: /\/\/.*/,
+  SemiColon: /;/,
   WhiteSpace: /\s/
 };
 

--- a/sample.hg
+++ b/sample.hg
@@ -40,7 +40,13 @@ while (i <= 10) {
   i = i + 1
 }
 
+// Semi-colons are mostly ignored
+sum(1,2);
+// They don't denote the end of a statement.
+;;;sum;(;1;,2;);;;
+
+
 // Stop program
-log ('Hello \'World\'')
+log ('Hello World')
 return 0
 log('This code will not execute')


### PR DESCRIPTION
Makes the language more tolerant of semi-colons